### PR TITLE
Update archive.php

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -11,15 +11,14 @@ get_header(); ?>
 <section class="container content-main archive clearfix">
 	<?php get_sidebar( 'left' ); ?>
 
-	<?php if( have_posts() ) : ?>
-		<div <?php layers_center_column_class(); ?>>
+	<div <?php layers_center_column_class(); ?>>
+		<?php if( have_posts() ) : ?>
 			<?php while( have_posts() ) : the_post(); ?>
 				<?php get_template_part( 'partials/content' , 'list' ); ?>
 			<?php endwhile; // while has_post(); ?>
-
 			<?php the_posts_pagination(); ?>
-		</div>
-	<?php endif; // if has_post() ?>
+		<?php endif; // if has_post() ?>
+	</div>
 
 	<?php get_sidebar( 'right' ); ?>
 </section>


### PR DESCRIPTION
If an archive page have no posts then the layers_center_custom_class() isn't executed and therefore the content column is missing in generated html.
